### PR TITLE
Epic/04 observability

### DIFF
--- a/epic-04-observability/grafana/provisioning/dashboards/dashboards.yaml
+++ b/epic-04-observability/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,2 +1,11 @@
-﻿# TODO: Implement according to G4 guide and issue assignment.
+apiVersion: 1
 
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/epic-04-observability/grafana/provisioning/datasources/datasources.yaml
+++ b/epic-04-observability/grafana/provisioning/datasources/datasources.yaml
@@ -1,2 +1,9 @@
-﻿# TODO: Implement according to G4 guide and issue assignment.
+apiVersion: 1
 
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true
+    editable: false

--- a/epic-04-observability/k8s/grafana-deployment.yaml
+++ b/epic-04-observability/k8s/grafana-deployment.yaml
@@ -1,2 +1,32 @@
-﻿# TODO: Implement according to G4 guide and issue assignment.
+# Secret for Grafana Admin Password
+apiVersion: v1
+kind: Secret
+metadata:
+  name: monitoring-grafana-auth
+  namespace: transit-platform
+type: Opaque
+stringData:
+  admin-user: admin
+  admin-password: "SecureGrafanaPassword123!"
 
+---
+# Kong Route for Grafana (Ingress)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  namespace: transit-platform
+  annotations:
+    konghq.com/strip-path: "true"
+spec:
+  ingressClassName: kong
+  rules:
+    - http:
+        paths:
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: monitoring-grafana
+                port:
+                  number: 80

--- a/epic-04-observability/k8s/prometheus-servicemonitor.yaml
+++ b/epic-04-observability/k8s/prometheus-servicemonitor.yaml
@@ -49,12 +49,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: kong
+      app: kong-gateway
   namespaceSelector:
     matchNames:
       - transit-security
   endpoints:
-    - port: admin
+    - port: admin-api
       path: /metrics
       interval: 15s
 
@@ -89,7 +89,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: postgres
+      app: postgresql
   namespaceSelector:
     matchNames:
       - transit-data

--- a/epic-04-observability/k8s/prometheus-values.yaml
+++ b/epic-04-observability/k8s/prometheus-values.yaml
@@ -5,3 +5,13 @@ prometheus:
     # Configure to discover ServiceMonitors across namespaces without strict label matching
     serviceMonitorSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
+
+grafana:
+  admin:
+    existingSecret: monitoring-grafana-auth
+    userKey: admin-user
+    passwordKey: admin-password
+  grafana.ini:
+    server:
+      root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
+      serve_from_sub_path: true


### PR DESCRIPTION
Deploy Grafana in transit-platform namespace; connect to Prometheus as default data source #31 