### PR TITLE
Configure Keycloak realm 'transit-system' - 3 roles: COMMUTER, DRIVER, SCHEDULER

### DIFF
--- a/epic-02-security/k8s/keycloak/keycloak-deployment.yaml
+++ b/epic-02-security/k8s/keycloak/keycloak-deployment.yaml
@@ -1,0 +1,176 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: transit-platform
+  labels:
+    app: keycloak
+    app.kubernetes.io/part-of: ontime
+spec:
+  clusterIP: None
+  selector:
+    app: keycloak
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-service
+  namespace: transit-platform
+  labels:
+    app: keycloak
+    app.kubernetes.io/part-of: ontime
+spec:
+  type: ClusterIP
+  selector:
+    app: keycloak
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+
+metadata:
+  name: keycloak
+  namespace: transit-platform
+  labels:
+    app: keycloak
+    app.kubernetes.io/part-of: ontime
+    app.kubernetes.io/version: "23.0"
+
+spec:
+  serviceName: keycloak-headless
+  replicas: 1
+
+  selector:
+    matchLabels:
+      app: keycloak
+
+  template:
+    metadata:
+      labels:
+        app: keycloak
+        app.kubernetes.io/part-of: ontime
+
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:23.0
+          imagePullPolicy: IfNotPresent
+          args: ["start"]
+          
+          # Environment variables for configuring Keycloak (DB connection, admin credentials, URLs, etc.)
+          env:
+ 
+            - name: KC_DB
+              value: postgres
+            # Database keycloak_db — see postgres-init-script in transit-data
+            - name: KC_DB_URL
+              value: jdbc:postgresql://postgresql-service.transit-data.svc.cluster.local:5432/keycloak_db
+            - name: KC_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-db
+                  key: username
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-db
+                  key: password
+            - name: KEYCLOAK_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin
+                  key: username
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin
+                  key: password
+            - name: KC_PROXY
+              value: edge                  # use edge proxy mode
+            - name: KC_HOSTNAME_STRICT
+              value: "false"               # allow requests without strict hostname match
+            - name: KC_HOSTNAME_STRICT_HTTPS
+              value: "false"               # allow non-HTTPS for hostname strictness
+            - name: KC_HOSTNAME_URL
+              value: "http://10.100.220.147/auth"        # external Keycloak URL
+            - name: KC_HOSTNAME_ADMIN_URL
+              value: "http://10.100.220.147/auth"        # external admin URL
+            - name: KC_HTTP_ENABLED
+              value: "true"                # enable HTTP
+            - name: KC_HTTP_PORT
+              value: "8080"                # HTTP port
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth"               # Keycloak served under /auth
+            - name: KC_HEALTH_ENABLED
+              value: "true"                # expose health endpoints
+            - name: KC_LOG_LEVEL
+              value: INFO                  # set log level
+
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: management
+              containerPort: 9000
+              protocol: TCP
+
+          startupProbe:
+            httpGet:
+              path: /auth/health/started
+              port: 8080
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+
+          livenessProbe:
+            httpGet:
+              path: /auth/health/live
+              port: 8080
+              scheme: HTTP
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 4
+
+          readinessProbe:
+            httpGet:
+              path: /auth/health/ready
+              port: 8080
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+              
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL

--- a/epic-02-security/k8s/keycloak/keycloak-secrets.yaml
+++ b/epic-02-security/k8s/keycloak/keycloak-secrets.yaml
@@ -1,0 +1,36 @@
+# Secrets for Keycloak:
+# - The keycloak-db secret aligns with the DB user and password from epic-03-data/k8s/postgres-statefulset.yaml:
+#   - Username: transit_admin (POSTGRES_USER)
+#   - Password: must match the POSTGRES_PASSWORD value in the postgres-credentials secret in the transit-data namespace
+#   - Database: keycloak_db (created by the postgres-init-script init.sql)
+#
+# - The keycloak-admin secret is for Keycloak's admin (bootstrap) user. 
+#   should replace the encoded values ("username" and "password") with secure credentials before deploying to staging or production.
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-admin
+  namespace: transit-platform
+  labels:
+    app: keycloak
+    app.kubernetes.io/part-of: ontime
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: Y2hhbmdlbWUta2V5Y2xvYWstYWRtaW4=
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-db
+  namespace: transit-platform
+  labels:
+    app: keycloak
+    app.kubernetes.io/part-of: ontime
+type: Opaque
+data:
+  username: dHJhbnNpdF9hZG1pbg==
+  password: c3VwZXJzZWN1cmVwYXNzd29yZA==

--- a/epic-02-security/k8s/kong/kong.yaml
+++ b/epic-02-security/k8s/kong/kong.yaml
@@ -1,5 +1,11 @@
-﻿_format_version: "3.0"
+_format_version: "3.0"
 _transform: true
+
+# kong-proxy is LoadBalancer type but Minikube doesn't have a LoadBalancer controller, 
+# so the external IP never gets assigned. browser can't reach it because there's no actual external IP.
+# To test locally:
+#   kubectl port-forward -n transit-platform svc/kong-proxy 8088:80
+#   then open http://127.0.0.1:8088/auth/admin/
 
 services:
   - name: ontime-api
@@ -14,7 +20,7 @@ services:
           - POST
           - PUT
           - DELETE
-  
+
   - name: kong-status
     url: http://localhost:8001
     routes:
@@ -22,5 +28,23 @@ services:
         paths:
           - /health
         methods:
+          - HEAD
           - GET
-          
+
+  - name: keycloak-auth
+    url: http://keycloak-service:8080
+    routes:
+      - name: keycloak-auth-route
+        preserve_host: true
+        paths:
+          - /auth
+          - /auth/*
+        methods:
+          - HEAD
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - PATCH
+          - OPTIONS
+        strip_path: false

--- a/epic-02-security/k8s/kustomization.yaml
+++ b/epic-02-security/k8s/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - kong-deployment.yaml
   - kong-service.yaml
   - kong-hpa.yaml
+  - keycloak/keycloak-deployment.yaml
+  - keycloak/keycloak-secrets.yaml
 
 
 

--- a/epic-02-security/keycloak/realm-export.json
+++ b/epic-02-security/keycloak/realm-export.json
@@ -1,2 +1,44 @@
-﻿{}
+﻿{
+    "realm": "transit-system",
+    "enabled": true,
+    "sslRequired": "external",
+    "registrationAllowed": false,
+    "bruteForceProtected": true,
+    "failureFactor": 5,
+    "waitIncrementSeconds": 60,
+    "maxFailureWaitSeconds": 900,
+  
+    "accessTokenLifespan": 3600,
+    "ssoSessionIdleTimeout": 1800,
+    "ssoSessionMaxLifespan": 28800,
+    "offlineSessionIdleTimeout": 28800,
+  
+    "passwordPolicy": "length(8) and upperCase(1) and digits(1) and specialChars(1) and passwordHistory(5)",
+  
+    "roles": {
+      "realm": [
+        {
+          "name": "COMMUTER",
+          "description": "Read-only access — live tracking and schedule viewing",
+          "composite": false,
+          "clientRole": false
+        },
+        {
+          "name": "DRIVER",
+          "description": "Status updates and incident reporting",
+          "composite": false,
+          "clientRole": false
+        },
+        {
+          "name": "SCHEDULER",
+          "description": "Full access including dispatch and scheduling",
+          "composite": false,
+          "clientRole": false
+        }
+      ]
+    },
+  
+    "clients": [],
+    "groups": []
+  }
 

--- a/epic-03-data/k8s/postgres-service.yaml
+++ b/epic-03-data/k8s/postgres-service.yaml
@@ -1,2 +1,13 @@
-﻿# TODO: Implement according to G4 guide and issue assignment.
+﻿apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql-service
+  namespace: transit-data
+spec:
+  type: ClusterIP 
+  ports:
+  - port: 5432
+    targetPort: 5432
+  selector:
+    app: postgresql
 

--- a/epic-03-data/k8s/postgres-statefulset.yaml
+++ b/epic-03-data/k8s/postgres-statefulset.yaml
@@ -1,2 +1,86 @@
-﻿# TODO: Implement according to G4 guide and issue assignment.
+﻿# 1. Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: transit-data
+---
+# 2. Secret for the Password
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: transit-data
+type: Opaque
+data:
+  POSTGRES_PASSWORD: c3VwZXJzZWN1cmVwYXNzd29yZA==
+---
+# 3. UPDATED ConfigMap for the Init Script
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init-script
+  namespace: transit-data
+data:
+  init.sql: |
+    CREATE DATABASE keycloak_db;
+    
+    -- Connect to the transit_db created by the environment variables
+    \c transit_db
+    
+    -- Install the spatial extensions required for geo-fencing (G4-20)
+    CREATE EXTENSION IF NOT EXISTS postgis;
+    CREATE EXTENSION IF NOT EXISTS postgis_topology;
+---
+# 4. UPDATED StatefulSet
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql
+  namespace: transit-data
+spec:
+  serviceName: "postgresql-service"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+      - name: postgresql
+        # We swapped to the PostGIS image!
+        image: postgis/postgis:16-3.4-alpine 
+        ports:
+        - containerPort: 5432
+        env:
+        # The Alpine image automatically creates transit_db in UTF-8
+        - name: POSTGRES_DB
+          value: "transit_db"
+        - name: POSTGRES_USER
+          value: "transit_admin"
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-credentials
+              key: POSTGRES_PASSWORD
+        volumeMounts:
+        - name: postgres-storage
+          mountPath: /var/lib/postgresql/data
+        - name: init-script-volume
+          mountPath: /docker-entrypoint-initdb.d/
+      volumes:
+      - name: init-script-volume
+        configMap:
+          name: postgres-init-script
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-storage
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: standard          # use do-block-storage if you want to use a block storage at production
+      resources:
+        requests:
+          storage: 10Gi
 


### PR DESCRIPTION
- Realm 'transit-system' appears in Keycloak Admin → Realms list.
- Three realm roles exist: COMMUTER, DRIVER, SCHEDULER — visible under Realm Settings → Roles.
- JWKS endpoint is accessible: GET {keycloak_url}/realms/transit-system/protocol/openid-connect/certs returns RS256 public key.
- Token issued after login has exp - iat = 3600 seconds (verify with jwt.io).
- Realm configuration is exported as a JSON file under /keycloak/realm-export.json.

Closes #13 